### PR TITLE
Remove the 'View on Site' from admin site

### DIFF
--- a/oneplus/templates/admin/auth/change_form.html
+++ b/oneplus/templates/admin/auth/change_form.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls admin_static admin_modify %}
+
+{% block object-tools-items %}
+<li>
+    {% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
+    <a href="{% add_preserved_filters history_url %}" class="historylink">{% trans "History" %}</a>
+</li>
+{% endblock %}


### PR DESCRIPTION
In order to cater for the fact that the mobileu admin template is not being used by oneplus. 
