### PR TITLE
DIG-13 Feature/email include grade

### DIFF
--- a/oneplus/misc_views.py
+++ b/oneplus/misc_views.py
@@ -164,17 +164,21 @@ def contact(request, state, user):
 
         if "grade" in request.POST.keys():
             _grade = request.POST["grade"]
-            state['grade'] = _grade
+        else:
+            _grade = ""
+        state['grade'] = _grade
 
         if "school" in request.POST.keys():
             _school = request.POST["school"]
-            state['school'] = _school
+        else:
+            _school = ""
+        state['school'] = _school
 
         if state['valid']:
             message = "\n".join([
                 "First Name: " + _fname,
                 "Last Name: " + _sname,
-                "Grade: " + ("Grade %s" % _grade if (_grade != "") else "Not specified"),
+                "Grade: " + ("" if _grade == "" else "Grade " + _grade),
                 "School: " + _school,
                 "Contact: " + _contact,
                 _comment,

--- a/oneplus/misc_views.py
+++ b/oneplus/misc_views.py
@@ -111,11 +111,17 @@ def about(request, state, user):
 @oneplus_check_user
 def contact(request, state, user):
     def get():
+        state['grades'] = (
+            {"id": 10, "text": "Grade 10"},
+            {"id": 11, "text": "Grade 11"},
+            {"id": 12, "text": "Grade 12"}
+        )
         state["sent"] = False
         state['fname'] = ""
         state['sname'] = ""
         state['comment'] = ""
         state['contact'] = ""
+        state['grade'] = ""
         state['school'] = ""
         state['valid_message'] = ""
 
@@ -156,6 +162,10 @@ def contact(request, state, user):
             state['valid'] = False
             state['valid_message'].append("Message")
 
+        if "grade" in request.POST.keys():
+            _grade = request.POST["grade"]
+            state['grade'] = _grade
+
         if "school" in request.POST.keys():
             _school = request.POST["school"]
             state['school'] = _school
@@ -164,6 +174,7 @@ def contact(request, state, user):
             message = "\n".join([
                 "First Name: " + _fname,
                 "Last Name: " + _sname,
+                "Grade: " + ("Grade %s" % _grade if (_grade != "") else "Not specified"),
                 "School: " + _school,
                 "Contact: " + _contact,
                 _comment,

--- a/oneplus/static/css/oneplus.css
+++ b/oneplus/static/css/oneplus.css
@@ -11,7 +11,7 @@ body {
     box-sizing: border-box;
 }
 
-input[type=submit], input[type=text], input[type=password] {
+input[type=submit], input[type=text], input[type=password], select {
     -webkit-appearance: none;
     border-radius: 0;
 }
@@ -76,7 +76,7 @@ button {white-space: nowrap; }
     border:none;
 }
 
-input[type=text],input[type=password] { width: 100%; background-color: #444444; height: 35px; border:none; color:#dbdbdb; padding-left:10px; padding-right:10px; -webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box; }
+input[type=text],input[type=password], select { width: 100%; background-color: #444444; height: 35px; border:none; color:#dbdbdb; padding-left:10px; padding-right:10px; -webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box; }
 textarea { width: 100%; background-color: #444444; height: 80px; border:none; color:#dbdbdb; padding-left:10px; padding-right:10px; -webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box; }
 
 .login label { z-index: 1; display: block; }
@@ -643,6 +643,11 @@ li.down_red {
 }
 
 .comment > textarea{
+    padding-right: 50px;
+    margin-top:10px;
+}
+
+.comment > select{
     padding-right: 50px;
     margin-top:10px;
 }

--- a/oneplus/templates/misc/contact.html
+++ b/oneplus/templates/misc/contact.html
@@ -32,6 +32,13 @@
                 <input type="text" name="sname" value="{{ state.sname }}"><br><br/>
                 Mobile number or email address:
                 <input type="text" name="contact" value="{{ state.contact }}"><br><br/>
+                Grade:
+                <select name="grade" value="{{ state.grade }}">
+                    <option value="">- - - - - - - -</option>
+                    {% for gr in state.grades %}
+                        <option value="{{ gr.id }}">{{ gr.text }}</option>
+                    {% endfor %}
+                </select><br><br/>
                 School:
                 <input type="text" name="school" value="{{ state.school }}"><br><br/>
                 Message:

--- a/oneplus/tests/test_general_tests.py
+++ b/oneplus/tests/test_general_tests.py
@@ -2558,6 +2558,7 @@ class GeneralTests(TestCase):
                 "contact": "0123456789",
                 "comment": "test",
                 "school": "Test School",
+                "grade": "11",
             }
         )
 
@@ -2576,6 +2577,7 @@ class GeneralTests(TestCase):
                     "contact": "0123456789\n0123456789\n0123456789",
                     "comment": "test",
                     "school": "Test School",
+                    "grade": "11"
                 }
             )
 
@@ -2583,7 +2585,7 @@ class GeneralTests(TestCase):
 
             mock_mail_managers.assert_called_(
                 fail_silently=False,
-                message=u"First Name: Test\nLast Name: test\nSchool: Test School\nContact: 0123456789 0123456789 0123456789\ntest",
+                message=u"First Name: Test\nLast Name: test\nGrade: Grade 11\nSchool: Test School\nContact: 0123456789 0123456789 0123456789\ntest",
                 subject=u"Contact Us Message - 0123456789 0123456789 0123456789"
             )
 


### PR DESCRIPTION
Adds a `select` element dropdown list to the `Contact us` form for `Grade` and styles it in the same way as `input[type=text]` elements. Users can select "Grade 10", "Grade 11", "Grade 12". The new field is included in the e-mail to admins.
