### PR TITLE
Move next button on wrong page.

### DIFF
--- a/oneplus/templates/learn/redo_wrong.html
+++ b/oneplus/templates/learn/redo_wrong.html
@@ -17,14 +17,6 @@
             That's not the correct answer.
         </h2>
 
-
-        {% if not preview %}
-            {% if has_next %}
-                <a class="button border-color-accent color-accent" href="redo">Next question</a>
-            {% else %}
-                <a class="button border-color-accent color-accent" href="home">Done for today</a>
-            {% endif %}
-        {% endif %}
         <article class="card pale-teal-accent border-color-accent">
             {% autoescape off %}
             {{ state.question_id }}
@@ -59,6 +51,14 @@
             {% endif %}
             {% endautoescape %}
         </article>
+    
+        {% if not preview %}
+            {% if has_next %}
+                <a class="button border-color-accent color-accent" href="redo">Next question</a>
+            {% else %}
+                <a class="button border-color-accent color-accent" href="home">Done for today</a>
+            {% endif %}
+        {% endif %}
 
         {% if not preview %}
             <p>Find a mistake? Report it <a href="/report_question/{{ question.id }}/wrong">here</a></p>

--- a/oneplus/templates/learn/wrong.html
+++ b/oneplus/templates/learn/wrong.html
@@ -18,14 +18,6 @@
             That's not the correct answer.
         </h2>
 
-        {% if not preview %}
-            {% if state.right_tasks_today >= state.total_tasks_today %}
-                <a class="button border-color-accent color-accent" href="home">Done for today</a>
-            {% else %}
-                <a class="button border-color-accent color-accent" href="next">Next question</a>
-            {% endif %}
-        {% endif %}
-
         <article class="card pale-teal-accent border-color-accent">
             {% autoescape off %}
             {{ state.question_id }}
@@ -60,6 +52,14 @@
             {% endif %}
             {% endautoescape %}
         </article>
+
+        {% if not preview %}
+            {% if state.right_tasks_today >= state.total_tasks_today %}
+                <a class="button border-color-accent color-accent" href="home">Done for today</a>
+            {% else %}
+                <a class="button border-color-accent color-accent" href="next">Next question</a>
+            {% endif %}
+        {% endif %}
 
         {% if not preview %}
             <div class="padded">


### PR DESCRIPTION
- [x] Move the "Next"/"Done" button when learners answer incorrectly, to encourage them to read the solution before going to the next question.