### PR TITLE
Fix ElasticSearch error handling.

### DIFF
--- a/oneplus/auth_views.py
+++ b/oneplus/auth_views.py
@@ -279,8 +279,7 @@ def signup_form_normal(request):
                     for entry in school_list:
                         entry['id'] = entry.pop('pk')
                 except:
-                    school_list = None
-                finally:
+
                     if not school_list or len(school_list) == 0:
                         school_list = School.objects.filter(province=data['province'],
                                                             name__icontains=data['school_dirty']).values()[:10]

--- a/oneplusmvp/settings.py
+++ b/oneplusmvp/settings.py
@@ -127,6 +127,7 @@ HAYSTACK_CONNECTIONS = {
         'ENGINE': 'mobileu.haystack_custom.FuzzyEngine',
         'URL': os.environ.get('ELASTICSEARCH_URL', 'http://127.0.0.1:9200/'),
         'INDEX_NAME': 'haystack',
+        'SILENTLY_FAIL': False,
     },
 }
 


### PR DESCRIPTION
- [x] Stop ElasticSearch queries from silently failing, so that errors can be caught and handled properly.