### PR TITLE
Use correct timeframe for learner admin and export.

### DIFF
--- a/oneplus/admin.py
+++ b/oneplus/admin.py
@@ -16,6 +16,18 @@ class OnePlusLearnerResource(LearnerResource):
     completed_questions = fields.Field(column_name=u'completed_questions')
     percentage_correct = fields.Field(column_name=u'percentage_correct')
 
+    def dehydrate_completed_questions(self, learner):
+        if hasattr(learner, 'total'):
+            return learner.total
+        else:
+            return super(LearnerResource, self).dehydrate_completed_questions(learner)
+
+    def dehydrate_percentage_correct(self, learner):
+        if hasattr(learner, 'perc'):
+            return learner.perc
+        else:
+            return super(LearnerResource, self).dehydrate_percentage_correct(learner)
+
     def import_obj(self, obj, data, dry_run):
         school, created = School.objects.get_or_create(name=data[u'school'])
         data[u'school'] = school.id

--- a/oneplus/filters.py
+++ b/oneplus/filters.py
@@ -162,7 +162,7 @@ def get_timeframe_range(value):
     if value == "1":
         # last week
         start = today - timedelta(days=dw, weeks=1)
-        end = start + timedelta(6 - dw)
+        end = start + timedelta(weeks=1, days=-1)
     elif value == "2":
         # this month
         start = today.replace(day=1)
@@ -196,7 +196,7 @@ def get_timeframe_range(value):
     else:
         # this week
         start = today - timedelta(days=dw)
-        end = start + timedelta(6 - dw)
+        end = start + timedelta(weeks=1, days=-1)
 
     start = start.replace(hour=0, minute=0, second=0, microsecond=0)
     end = end.replace(hour=23, minute=59, second=59, microsecond=999999)


### PR DESCRIPTION
When a timeframe is specified the correct values are loaded into `perc` and `total`. This makes the export resource aware of those columns, so that timeframe is carried over from the admin interface.