### PR TITLE
Correctly store field for sending SMS to all learners.

### DIFF
--- a/oneplus/templates/admin/auth/send_message.html
+++ b/oneplus/templates/admin/auth/send_message.html
@@ -35,6 +35,7 @@
 
         <input type="hidden" name="action" value="send_message" />
         <input type="hidden" name="post" value="yes" />
+        <input type="hidden" name="select_across" value="{{ request.POST.select_across }}" />
         <input type="submit" name="apply" value="Send Message" />
     </form>
 

--- a/oneplus/templates/admin/auth/send_sms.html
+++ b/oneplus/templates/admin/auth/send_sms.html
@@ -19,6 +19,7 @@
     <br><br/>
     <input type="hidden" name="action" value="send_sms" />
     <input type="hidden" name="post" value="yes" />
+    <input type="hidden" name="select_across" value="{{ request.POST.select_across }}" />
     <input type="submit" name="apply" value="Send smses" />
 </form>
 


### PR DESCRIPTION
Django apparently checks for a field `select_across` when determining whether to select _all_ objects for a queryset with admin actions. If this isn't stored on the intermediary page, it only applies to objects selected on the page beforehand.