### PR TITLE
[DIG-216] Add Google Tag Manager to base page templates.

### DIFF
--- a/oneplus/templates/core/main.html
+++ b/oneplus/templates/core/main.html
@@ -2,6 +2,15 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-PL25792');</script>
+    <!-- End Google Tag Manager -->
+
     <link href="//fonts.googleapis.com/css?family=Asap|Lato" rel="stylesheet">
     <title>DIG-IT | {% block title %}{% endblock %}</title>
     {% load static %}
@@ -15,6 +24,11 @@
     <meta property="og:type" content="website" />
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PL25792"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     {% load google_analytics_tags %}
     <img src="{% google_analytics %}" class="analytics-plug" />
 

--- a/oneplus/templates/public/public_main.html
+++ b/oneplus/templates/public/public_main.html
@@ -2,6 +2,15 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-PL25792');</script>
+    <!-- End Google Tag Manager -->
+
     <link href="//fonts.googleapis.com/css?family=Asap|Lato" rel="stylesheet">
     <title>DIG-IT | {% block title %}{% endblock %}</title>
     {% load static %}
@@ -25,6 +34,11 @@
     <meta property="og:type" content="website" />
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PL25792"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     {% load google_analytics_tags %}
     <img src="{% google_analytics %}" class="analytics-plug" />
 


### PR DESCRIPTION
Insert Google Tag Manager code into base page templates.

Original instructions (formatted for readability):
>>>
Copy the code below and paste it onto every page of your website.

Paste this code as high in the `<head>` of the page as possible:

```html
<!-- Google Tag Manager -->
<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
{'gtm.start': new Date().getTime(),event:'gtm.js'}
);var f=d.getElementsByTagName(s)[0],
j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
})(window,document,'script','dataLayer','GTM-PL25792');</script>
<!-- End Google Tag Manager -->
```

Additionally, paste this code immediately after the opening <body> tag:

```html
<!-- Google Tag Manager (noscript) -->
<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PL25792"
height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
<!-- End Google Tag Manager (noscript) -->
```

For more information about installing the Google Tag Manager snippet, visit our Quick Start Guide. (https://developers.google.com/tag-manager/quickstart)
